### PR TITLE
Improve build speed by reusing computations from previous builds

### DIFF
--- a/update_metalava.sh
+++ b/update_metalava.sh
@@ -16,10 +16,10 @@ fi
     echo " Done"
 
     echo -n "Building…"
-    ./gradlew jar --console=plain -q --no-daemon
+    ./gradlew jar --console=plain -q --daemon
     find ../../out/host/common/libs ! -name '*full*' -type f -exec cp {} ../../../../metalava.jar \;
     echo " Done"
 
     echo -e "\nDependencies:\n"
-    ./gradlew dependencies --no-daemon --configuration implementation | \egrep '^.--- ' | cut -d' ' -f2
+    ./gradlew dependencies --daemon --configuration implementation | \egrep '^.--- ' | cut -d' ' -f2
 )


### PR DESCRIPTION

[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
